### PR TITLE
chore: Update retry group names

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,9 +115,7 @@ const run = (opts, num = 0, retryGroup = undefined, spec = undefined) => {
       // If we're using parallelization, set a new group name
       let retryGroupName
       if (config.group) {
-        retryGroupName = `${opts.group}: retry #${num} (${specs.length} spec${
-          specs.length === 1 ? '' : 's'
-        } on ${uniqueId})`
+        retryGroupName = `${opts.group}: retry #${num}`
       }
 
       // kick off a new suite run


### PR DESCRIPTION
Drop the machine name and retry in the group name. It has been causing issues and is a bit confusing to see on the dashboard. We don't really care what machine id something is run on or how many retries there are. We only care about which retry number we're currently in.

Before:
![cypress-run__14](https://user-images.githubusercontent.com/338257/57476981-f719e700-7254-11e9-8309-2c1bb0e2bfd8.png)

After:
![cypress-run__15](https://user-images.githubusercontent.com/338257/57477097-2b8da300-7255-11e9-9b63-f34c76ce76ee.png)
